### PR TITLE
Fix storaged access to /sys/block/mmcblk0/stat after Iea1ba0

### DIFF
--- a/private/storaged.te
+++ b/private/storaged.te
@@ -8,6 +8,11 @@ init_daemon_domain(storaged)
 r_dir_file(storaged, proc_net)
 r_dir_file(storaged, domain)
 
+# Allow read access to /sys/block/mmcblk0/stat or /sys/block/sda/stat.
+# Implementations typically have symlinks to vendor specific files.
+# Vendors should mark sysfs_disk_stat on all files read by storaged.
+r_dir_file(storaged, sysfs_disk_stat)
+
 # Read /proc/uid_io/stats
 allow storaged proc_uid_io_stats:file r_file_perms;
 

--- a/public/file.te
+++ b/public/file.te
@@ -11,6 +11,7 @@ type proc_overcommit_memory, fs_type, proc_type;
 type proc_min_free_order_shift, fs_type, proc_type;
 # proc, sysfs, or other nodes that permit configuration of kernel usermodehelpers.
 type usermodehelper, fs_type, proc_type;
+type sysfs_disk_stat, fs_type, sysfs_type;
 type sysfs_usermodehelper, fs_type, sysfs_type;
 type qtaguid_proc, fs_type, mlstrustedobject, proc_type;
 type proc_qtaguid_stat, fs_type, mlstrustedobject, proc_type;


### PR DESCRIPTION
* Commit "storaged: remove access to sysfs_type" denied the storaged
  daemon access to the sysfs node it needed to do its work.
* It also didn't provide any means necessary for adding the necessary
  rules at a device level, since its sepolicy is private.
* Here we define a new sysfs_disk_stat security label, which device
  maintainers are supposed to add to their genfs_contexts file. This is
  similar to how hal_health_default and sysfs_batteryinfo is handled.
* What prevents the genfs_contexts from being added here directly is
  that in a typical vendor implementation, these sysfs files are
  actually symlinks and not a single, unified path SELinux-wise.

Change-Id: I13ca09cf2458b22ffb6c70b8a353e891e810c606
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>